### PR TITLE
drivers: nrf_qspi_nor: Add support for S2B1v5 QER

### DIFF
--- a/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
+++ b/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
@@ -107,7 +107,7 @@
 		has-dpd;
 		t-enter-dpd = <20000>;
 		t-exit-dpd = <20000>;
-                quad-enable-requirements = "S2B1v4";
+                quad-enable-requirements = "S2B1v5";
 	};
 };
 


### PR DESCRIPTION
Add support for S2B1v4 quad-enable-requirements. Tested with GD25q16
on the Adafruit feather nrf52840 on board chip